### PR TITLE
Updated Android Studio to Electric Eel | 2022.1.1 Patch 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
         build-essential git neovim wget unzip sudo \
         libc6:i386 libncurses5:i386 libstdc++6:i386 lib32z1 libbz2-1.0:i386 \
         libxrender1 libxtst6 libxi6 libfreetype6 libxft2 xz-utils vim\
-        qemu qemu-kvm libvirt-bin ubuntu-vm-builder bridge-utils libnotify4 libglu1 libqt5widgets5 openjdk-8-jdk xvfb \
+        qemu qemu-kvm libvirt-bin ubuntu-vm-builder bridge-utils libnotify4 libglu1 libqt5widgets5 openjdk-8-jdk openjdk-11-jdk xvfb \
         && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -45,8 +45,8 @@ RUN tar -xvf flutter.tar.xz
 RUN rm flutter.tar.xz
 
 #Android Studio
-ARG ANDROID_STUDIO_URL=https://redirector.gvt1.com/edgedl/android/studio/ide-zips/4.1.3.0/android-studio-ide-201.7199119-linux.tar.gz
-ARG ANDROID_STUDIO_VERSION=4.1.3
+ARG ANDROID_STUDIO_URL=https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2022.1.1.21/android-studio-2022.1.1.21-linux.tar.gz
+ARG ANDROID_STUDIO_VERSION=2022.1.1.21
 
 RUN wget "$ANDROID_STUDIO_URL" -O android-studio.tar.gz
 RUN tar xzvf android-studio.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-mkdir -p studio-data/profile/AndroidStudio4.1.3 || exit
+mkdir -p studio-data/profile/AndroidStudio2022.1.1.21 || exit
 mkdir -p studio-data/Android || exit
 mkdir -p studio-data/profile/.android || exit
 mkdir -p studio-data/profile/.java || exit

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ AOSP_ARGS="${AOSP_ARGS} --env=DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix"
 fi
 
 #Make sure prerequisite directories exist in studio-data dir
-mkdir -p studio-data/profile/AndroidStudio${ANDROID_STUDIO_VERSION}
+mkdir -p studio-data/profile/AndroidStudio2022.1.1.21
 mkdir -p studio-data/profile/android
 mkdir -p studio-data/profile/gradle
 mkdir -p studio-data/profile/java


### PR DESCRIPTION
Hey @Deadolus, thanks a lot for creating the Docker image!

Sending pull request for your consideration, where I updated Android Studio to Electric Eel release.
By my understanding, this should be last stable release which still uses Java 11 and not Java 17.

I haven't done any extensive development with this updated version. Just used it to run Snowplow Demo for my testing purposes: https://github.com/snowplow/snowplow-android-tracker

The demo wouldn't compile with the old version. It compiled and ran successfully in emulator with Electric Eel.

Feel free to validate and reject my pull request in case is still broken.

Thanks again, really appreciate your work on the original image.
Michal
