### PR TITLE
Added docker compose capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ RUN chown $USER:$USER /androidstudio-data
 RUN mkdir -p /studio-data/Android/Sdk && \
     chown -R $USER:$USER /studio-data/Android
 
+
+RUN mkdir -p /studio-data/profile/android && \
+    chown -R $USER:$USER /studio-data/profile
+
 COPY provisioning/docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 COPY provisioning/ndkTests.sh /usr/local/bin/ndkTests.sh
 RUN chmod +x /usr/local/bin/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN mkdir -p /androidstudio-data
 VOLUME /androidstudio-data
 RUN chown $USER:$USER /androidstudio-data
 
+RUN mkdir -p /studio-data/Android/Sdk && \
+    chown -R $USER:$USER /studio-data/Android
+
 COPY provisioning/docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 COPY provisioning/ndkTests.sh /usr/local/bin/ndkTests.sh
 RUN chmod +x /usr/local/bin/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN echo "$USER:$USER" | chpasswd
 RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/90-$USER
 RUN usermod -aG sudo $USER
 RUN usermod -aG plugdev $USER
-
+RUN mkdir -p /androidstudio-data
 VOLUME /androidstudio-data
 RUN chown $USER:$USER /androidstudio-data
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ If you don't have a display the Emulator can run with a "dummy" display - perfec
 
 Tested on Linux only.
 
-Building
+Building without docker compose
 -------------
 Just run "./build.sh", or "docker build -t deadolus/android-studio ." directly.
 An already built version is also on Docker Hub. So you may also run "docker pull deadolus/android-studio".
@@ -39,15 +39,12 @@ So it probably does not make sense to try starting via run.sh without
 HOST_DISPLAY=1.
 If you just want a shell in the container, without starting Android Studio, run "./run.sh bash" to bypass starting Android Studio
 
-Running with Docker Compose
+Running and Building with docker compose:
 -------------
-Comment/uncomment the appropriate lines in the compose.yaml depending on if you are running this natively in linux or in WSL.
-Run
-`docker compose build android_emulator`
 
-then run
-
-`docker compose run android_emulator`
+1. Comment/uncomment the appropriate lines in the compose.yaml depending on if you are running this natively in linux or in WSL.
+2. To build: `docker compose build android_emulator`
+3. To run: `docker compose run android_emulator`
 
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Just run "./build.sh", or "docker build -t deadolus/android-studio ." directly.
 An already built version is also on Docker Hub. So you may also run "docker pull deadolus/android-studio".
 You may of course change the name of the container.
 
-Running
+Running without docker compose
 -------------
 Run
 
@@ -39,6 +39,18 @@ So it probably does not make sense to try starting via run.sh without
 HOST_DISPLAY=1.
 If you just want a shell in the container, without starting Android Studio, run "./run.sh bash" to bypass starting Android Studio
 
+Running with Docker Compose
+-------------
+Comment/uncomment the appropriate lines in the compose.yaml depending on if you are running this natively in linux or in WSL.
+Run
+`docker compose build android_emulator`
+
+then run
+
+`docker compose run android_emulator`
+
+
+
 Additional information - continous integration
 -------------
 I included a script under provisioning/ndkTests.sh which demonstrates how you may use this container in a CI environment.
@@ -53,3 +65,5 @@ Contributors
 [@guilhermelinhares](https://github.com/guilhermelinhares)  
 [@mtomcanyi](https://github.com/mtomcanyi)  
 [@Naveenkhegde](https://github.com/Naveenkhegde)
+[@BenBlumer](https://github.com/BenBlumer)
+

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  android_emulator:
+    image: deadolus/android-studio
+    build: .
+    volumes:
+      - ./studio-data/profile/AndroidStudio2022.3.1.20:/studio-data/profile/AndroidStudio2022.3.1.20
+      - ./studio-data/Android:/studio-data/Android
+      - ./studio-data/profile/.android:/studio-data/profile/.android
+      - ./studio-data/profile/.java:/studio-data/profile/.java
+      - ./studio-data/profile/.gradle:/studio-data/profile/.gradle
+     # - /mnt/wslg/.X11-unix:/tmp/.X11-unix # Mount the proper location for X11 server if you are running this in WSL
+      - /tmp/.X11-unix:/tmp/.X11-unix #Comment out this line and uncomment above if you are running WSL
+      - android_studio:/androidstudio-data
+    environment:
+      - DISPLAY=:0 # Set DISPLAY environment variable
+    privileged: true
+    group_add:
+      - plugdev
+    network_mode: "host"
+#    devices:
+      # Uncomment the next line if you want to pass through USB to the container.
+      # - /dev/bus/usb:/dev/bus/usb
+    hostname: "${DOCKERHOSTNAME:-default-hostname}" # Use default hostname if DOCKERHOSTNAME is not set
+
+volumes:
+  android_studio:

--- a/compose.yml
+++ b/compose.yml
@@ -10,8 +10,8 @@ services:
       - ./studio-data/profile/.android:/studio-data/profile/.android
       - ./studio-data/profile/.java:/studio-data/profile/.java
       - ./studio-data/profile/.gradle:/studio-data/profile/.gradle
-     # - /mnt/wslg/.X11-unix:/tmp/.X11-unix # Mount the proper location for X11 server if you are running this in WSL
-      - /tmp/.X11-unix:/tmp/.X11-unix #Comment out this line and uncomment above if you are running WSL
+      - /mnt/wslg/.X11-unix:/tmp/.X11-unix # Mount the proper location for X11 server if you are running this in WSL
+#      - /tmp/.X11-unix:/tmp/.X11-unix #Comment out this line and uncomment above if you are running WSL
       - android_studio:/androidstudio-data
     environment:
       - DISPLAY=:0 # Set DISPLAY environment variable
@@ -23,6 +23,6 @@ services:
       # Uncomment the next line if you want to pass through USB to the container.
       # - /dev/bus/usb:/dev/bus/usb
     hostname: "${DOCKERHOSTNAME:-default-hostname}" # Use default hostname if DOCKERHOSTNAME is not set
-
+    entrypoint: /usr/local/bin/docker_entrypoint.sh
 volumes:
   android_studio:

--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,7 @@ services:
 #    devices:
       # Uncomment the next line if you want to pass through USB to the container.
       # - /dev/bus/usb:/dev/bus/usb
-    hostname: "${DOCKERHOSTNAME:-default-hostname}" # Use default hostname if DOCKERHOSTNAME is not set
+#    hostname: "${DOCKERHOSTNAME:-default-hostname}" # Use default hostname if DOCKERHOSTNAME is not set
     entrypoint: /usr/local/bin/docker_entrypoint.sh
 volumes:
   android_studio:

--- a/compose.yml
+++ b/compose.yml
@@ -10,8 +10,10 @@ services:
       - ./studio-data/profile/.android:/studio-data/profile/.android
       - ./studio-data/profile/.java:/studio-data/profile/.java
       - ./studio-data/profile/.gradle:/studio-data/profile/.gradle
-      - /mnt/wslg/.X11-unix:/tmp/.X11-unix # Mount the proper location for X11 server if you are running this in WSL
-#      - /tmp/.X11-unix:/tmp/.X11-unix #Comment out this line and uncomment above if you are running WSL
+       # Mount the proper location for X11 server if you are running this in WSL
+      - /mnt/wslg/.X11-unix:/tmp/.X11-unix
+       # Mount the proper locationm for x11 server if you are running this in native linux
+#      - /tmp/.X11-unix:/tmp/.X11-unix .
       - android_studio:/androidstudio-data
     environment:
       - DISPLAY=:0 # Set DISPLAY environment variable
@@ -20,9 +22,8 @@ services:
       - plugdev
     network_mode: "host"
 #    devices:
-      # Uncomment the next line if you want to pass through USB to the container.
+      # Uncomment the previous and next line if you want to pass through USB to the container.
       # - /dev/bus/usb:/dev/bus/usb
-#    hostname: "${DOCKERHOSTNAME:-default-hostname}" # Use default hostname if DOCKERHOSTNAME is not set
     entrypoint: /usr/local/bin/docker_entrypoint.sh
 volumes:
   android_studio:

--- a/provisioning/docker_entrypoint.sh
+++ b/provisioning/docker_entrypoint.sh
@@ -5,6 +5,12 @@ echo "`whoami`" | sudo -S chmod 777 /dev/kvm > /dev/null 2>&1
 
 export PATH=$PATH:/studio-data/platform-tools/
 
+# Ensure the Android directory exists and has the correct permissions
+if [ ! -d "/studio-data/Android" ]; then
+  mkdir -p /studio-data/Android
+fi
+sudo chown -R android:android /studio-data/Android
+
 # Default to 'bash' if no arguments are provided
 args="$@"
 if [ -z "$args" ]; then

--- a/run.sh
+++ b/run.sh
@@ -13,8 +13,8 @@ fi
 if [ "$HOST_NET" != "" ]; then
 AOSP_ARGS="${AOSP_ARGS} --net=host"
 fi
-if [ "$HOST_DISPLAY" = "" ]; then
-AOSP_ARGS="${AOSP_ARGS} -e DISPLAY=:0 -v /mnt/c/tmp/.X11-unix:/tmp/.X11-unix"
+if [ "$HOST_DISPLAY" != "" ]; then
+AOSP_ARGS="${AOSP_ARGS} --env=DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix"
 fi
 
 #Make sure prerequisite directories exist in studio-data dir
@@ -23,5 +23,4 @@ mkdir -p studio-data/profile/android
 mkdir -p studio-data/profile/gradle
 mkdir -p studio-data/profile/java
 docker volume create --name=android_studio
-echo ${AOSP_ARGS}
 docker run -i $AOSP_ARGS -v `pwd`/studio-data:/studio-data -v android_studio:/androidstudio-data --privileged --group-add plugdev deadolus/android-studio $@

--- a/run.sh
+++ b/run.sh
@@ -13,8 +13,8 @@ fi
 if [ "$HOST_NET" != "" ]; then
 AOSP_ARGS="${AOSP_ARGS} --net=host"
 fi
-if [ "$HOST_DISPLAY" != "" ]; then
-AOSP_ARGS="${AOSP_ARGS} --env=DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix"
+if [ "$HOST_DISPLAY" = "" ]; then
+AOSP_ARGS="${AOSP_ARGS} -e DISPLAY=:0 -v /mnt/c/tmp/.X11-unix:/tmp/.X11-unix"
 fi
 
 #Make sure prerequisite directories exist in studio-data dir
@@ -23,4 +23,5 @@ mkdir -p studio-data/profile/android
 mkdir -p studio-data/profile/gradle
 mkdir -p studio-data/profile/java
 docker volume create --name=android_studio
+echo ${AOSP_ARGS}
 docker run -i $AOSP_ARGS -v `pwd`/studio-data:/studio-data -v android_studio:/androidstudio-data --privileged --group-add plugdev deadolus/android-studio $@


### PR DESCRIPTION
With this, you can just run

`docker compose build android_emulator` to build and then run `docker compose run android_emulator` to run it.

